### PR TITLE
Removed redundant timestamp from comcasted.sh

### DIFF
--- a/comcasted.sh
+++ b/comcasted.sh
@@ -2,7 +2,7 @@
 set -e
 
 function log {
-    echo -e "[$(date)]: $*"
+    echo -e "$*"
 }
 
 function logerr {


### PR DESCRIPTION
This timestamp was causing issues when trying to use visualize.py:

```
$ ./visualize.py 1
Using '/Users/mierdin/Desktop/comcasted.csv'.
Traceback (most recent call last):
  File "./visualize.py", line 152, in <module>
    main()
  File "./visualize.py", line 57, in main
    done = visualize(csv_path, days_back)
  File "./visualize.py", line 62, in visualize
    data = _filter_csv(csv_path, days_back)
  File "./visualize.py", line 124, in _filter_csv
    mktime(strptime(date_str, "%Y-%m-%d %H:%M:%S")))
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/_strptime.py", line 467, in _strptime_time
    return _strptime(data_string, format)[0]
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/_strptime.py", line 325, in _strptime
    (data_string, format))
```

I decided to fix the issue at the source, to make the resulting file more "csv-like".
